### PR TITLE
Add chase camera example for 3D navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ Die Klassen konvertieren uebergebene CellSpaces, Transitions und States in entsp
 
 * **IndoorGMLExample** – zeigt einfache CellSpaces in einer Ebene.
 * **ElevatedCellSpacesExample** – verteilt CellSpaces auf unterschiedlichen Hoehen, sodass eine echte 3D-Ansicht entsteht. Die Navigation erfolgt ueber die JME-FlyCam.
+* **ChaseCameraExample** – demonstriert eine Orbit-Steuerung mit der JME-ChaseCamera, um das 3D-Modell per Maus zu drehen und zu zoomen.

--- a/src/main/java/org/indoorgml/example/ChaseCameraExample.java
+++ b/src/main/java/org/indoorgml/example/ChaseCameraExample.java
@@ -1,0 +1,104 @@
+package org.indoorgml.example;
+
+import com.jme3.app.SimpleApplication;
+import com.jme3.input.ChaseCamera;
+import com.jme3.scene.Node;
+import org.indoorgml.model.LineString;
+import org.indoorgml.model.Polygon;
+import org.indoorgml.model.StatePoint;
+import org.indoorgml.model.Vector3d;
+import org.indoorgml.visualizer.IndoorGMLVisualizer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Example application that demonstrates orbit navigation around
+ * a 3D IndoorGML scene using JME's ChaseCamera.
+ */
+public class ChaseCameraExample extends SimpleApplication {
+
+    private ChaseCamera chaseCam;
+
+    public static void main(String[] args) {
+        ChaseCameraExample app = new ChaseCameraExample();
+        app.start();
+    }
+
+    @Override
+    public void simpleInitApp() {
+        List<Polygon> cellSpaces = createCellSpaces();
+        List<StatePoint> states = createStates(cellSpaces);
+        List<LineString> transitions = createTransitions(states);
+
+        IndoorGMLVisualizer visualizer = new IndoorGMLVisualizer(assetManager);
+        Node scene = visualizer.buildScene(cellSpaces, transitions, states);
+        rootNode.attachChild(scene);
+
+        flyCam.setEnabled(false);
+        chaseCam = new ChaseCamera(cam, scene, inputManager);
+        chaseCam.setDefaultDistance(6f);
+        chaseCam.setMinDistance(2f);
+        chaseCam.setMaxDistance(20f);
+    }
+
+    private List<Polygon> createCellSpaces() {
+        List<Polygon> list = new ArrayList<>();
+        list.add(square(0, 0, 0));
+        list.add(square(3, 0, 1));
+        list.add(square(0, 3, 2));
+        return list;
+    }
+
+    private Polygon square(float x, float y, float z) {
+        Polygon poly = new Polygon();
+        poly.setVertices(Arrays.asList(
+                new Vector3d(x, y, z),
+                new Vector3d(x + 2, y, z),
+                new Vector3d(x + 2, y + 2, z),
+                new Vector3d(x, y + 2, z)
+        ));
+        poly.setIndices(Arrays.asList(0, 1, 2, 0, 2, 3));
+        return poly;
+    }
+
+    private List<StatePoint> createStates(List<Polygon> cells) {
+        List<StatePoint> states = new ArrayList<>();
+        for (Polygon p : cells) {
+            states.add(computeCentroid(p));
+        }
+        return states;
+    }
+
+    private StatePoint computeCentroid(Polygon poly) {
+        double x = 0;
+        double y = 0;
+        double z = 0;
+        List<Vector3d> vertices = poly.getVertices();
+        for (Vector3d v : vertices) {
+            x += v.getX();
+            y += v.getY();
+            z += v.getZ();
+        }
+        int n = vertices.size();
+        StatePoint state = new StatePoint();
+        state.setPosition(new Vector3d(x / n, y / n, z / n));
+        return state;
+    }
+
+    private List<LineString> createTransitions(List<StatePoint> states) {
+        List<LineString> lines = new ArrayList<>();
+        for (int i = 0; i < states.size(); i++) {
+            Vector3d a = states.get(i).getPosition();
+            Vector3d b = states.get((i + 1) % states.size()).getPosition();
+            LineString line = new LineString();
+            line.setVertices(Arrays.asList(
+                    new Vector3d(a.getX(), a.getY(), a.getZ()),
+                    new Vector3d(b.getX(), b.getY(), b.getZ())
+            ));
+            lines.add(line);
+        }
+        return lines;
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `ChaseCameraExample` showcasing orbit controls around a 3D scene
- document the new example in the README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6868c9e00410832fb786a35054ff64bb