### PR TITLE
Add TwoCellSpacesExample

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ Die Klassen konvertieren uebergebene CellSpaces, Transitions und States in entsp
 * **IndoorGMLExample** – zeigt einfache CellSpaces in einer Ebene.
 * **ElevatedCellSpacesExample** – verteilt CellSpaces auf unterschiedlichen Hoehen, sodass eine echte 3D-Ansicht entsteht. Die Navigation erfolgt ueber die JME-FlyCam.
 * **ChaseCameraExample** – demonstriert eine Orbit-Steuerung mit der JME-ChaseCamera, um das 3D-Modell per Maus zu drehen und zu zoomen.
+* **TwoCellSpacesExample** – baut zwei CellSpaces aus Polygonen auf, berechnet deren Schwerpunkte und verbindet sie mit einer Transition.

--- a/src/main/java/org/indoorgml/example/TwoCellSpacesExample.java
+++ b/src/main/java/org/indoorgml/example/TwoCellSpacesExample.java
@@ -1,0 +1,165 @@
+package org.indoorgml.example;
+
+import com.jme3.app.SimpleApplication;
+import com.jme3.scene.Node;
+import org.indoorgml.model.LineString;
+import org.indoorgml.model.Polygon;
+import org.indoorgml.model.StatePoint;
+import org.indoorgml.model.Vector3d;
+import org.indoorgml.visualizer.IndoorGMLVisualizer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Example that visualizes two 3D CellSpaces constructed from multiple
+ * polygons and connects their centroids with a transition.
+ */
+public class TwoCellSpacesExample extends SimpleApplication {
+
+    public static void main(String[] args) {
+        TwoCellSpacesExample app = new TwoCellSpacesExample();
+        app.start();
+    }
+
+    @Override
+    public void simpleInitApp() {
+        List<Polygon> cellSpace1 = createCellSpace1();
+        List<Polygon> cellSpace2 = createCellSpace2();
+
+        // Combine polygons for visualization
+        List<Polygon> allPolygons = new ArrayList<>();
+        allPolygons.addAll(cellSpace1);
+        allPolygons.addAll(cellSpace2);
+
+        List<StatePoint> states = Arrays.asList(
+                computeCentroid(cellSpace1),
+                computeCentroid(cellSpace2)
+        );
+
+        List<LineString> transitions = createTransition(states.get(0), states.get(1));
+
+        IndoorGMLVisualizer visualizer = new IndoorGMLVisualizer(assetManager);
+        Node scene = visualizer.buildScene(allPolygons, transitions, states);
+        rootNode.attachChild(scene);
+
+        flyCam.setMoveSpeed(5f);
+    }
+
+    private List<LineString> createTransition(StatePoint a, StatePoint b) {
+        LineString line = new LineString();
+        line.setVertices(Arrays.asList(
+                new Vector3d(a.getPosition().getX(), a.getPosition().getY(), a.getPosition().getZ()),
+                new Vector3d(b.getPosition().getX(), b.getPosition().getY(), b.getPosition().getZ())
+        ));
+        return Arrays.asList(line);
+    }
+
+    private StatePoint computeCentroid(List<Polygon> polygons) {
+        double x = 0;
+        double y = 0;
+        double z = 0;
+        int count = 0;
+        for (Polygon poly : polygons) {
+            for (Vector3d v : poly.getVertices()) {
+                x += v.getX();
+                y += v.getY();
+                z += v.getZ();
+                count++;
+            }
+        }
+        StatePoint state = new StatePoint();
+        state.setPosition(new Vector3d(x / count, y / count, z / count));
+        return state;
+    }
+
+    private Polygon poly(Vector3d v1, Vector3d v2, Vector3d v3, Vector3d v4) {
+        Polygon poly = new Polygon();
+        poly.setVertices(Arrays.asList(v1, v2, v3, v4));
+        poly.setIndices(Arrays.asList(0, 1, 2, 0, 2, 3));
+        return poly;
+    }
+
+    private List<Polygon> createCellSpace1() {
+        List<Polygon> list = new ArrayList<>();
+        list.add(poly(
+                new Vector3d(62762.3590635083, 49638.2654653775, 2500.0),
+                new Vector3d(62775.3752335849, 48947.8075238529, 2500.0),
+                new Vector3d(63522.3102633086, 48948.4819317082, 2500.0),
+                new Vector3d(63515.4374949107, 49639.4237948367, 2500.0)
+        ));
+        list.add(poly(
+                new Vector3d(62762.3590635083, 49638.2654653775, 0.0),
+                new Vector3d(62775.3752335849, 48947.8075238529, 0.0),
+                new Vector3d(62775.3752335849, 48947.8075238529, 2500.0),
+                new Vector3d(62762.3590635083, 49638.2654653775, 2500.0)
+        ));
+        list.add(poly(
+                new Vector3d(62775.3752335849, 48947.8075238529, 0.0),
+                new Vector3d(63522.3102633086, 48948.4819317082, 0.0),
+                new Vector3d(63522.3102633086, 48948.4819317082, 2500.0),
+                new Vector3d(62775.3752335849, 48947.8075238529, 2500.0)
+        ));
+        list.add(poly(
+                new Vector3d(63522.3102633086, 48948.4819317082, 0.0),
+                new Vector3d(63515.4374949107, 49639.4237948367, 0.0),
+                new Vector3d(63515.4374949107, 49639.4237948367, 2500.0),
+                new Vector3d(63522.3102633086, 48948.4819317082, 2500.0)
+        ));
+        list.add(poly(
+                new Vector3d(63515.4374949107, 49639.4237948367, 0.0),
+                new Vector3d(62762.3590635083, 49638.2654653775, 0.0),
+                new Vector3d(62762.3590635083, 49638.2654653775, 2500.0),
+                new Vector3d(63515.4374949107, 49639.4237948367, 2500.0)
+        ));
+        list.add(poly(
+                new Vector3d(62762.3590635083, 49638.2654653775, 0.0),
+                new Vector3d(63515.4374949107, 49639.4237948367, 0.0),
+                new Vector3d(63522.3102633086, 48948.4819317082, 0.0),
+                new Vector3d(62775.3752335849, 48947.8075238529, 0.0)
+        ));
+        return list;
+    }
+
+    private List<Polygon> createCellSpace2() {
+        List<Polygon> list = new ArrayList<>();
+        list.add(poly(
+                new Vector3d(63459.7496755729, 48913.971239468, 2500.0),
+                new Vector3d(63458.4604999209, 48948.4242817383, 2500.0),
+                new Vector3d(62813.8517414851, 48947.842264303, 2500.0),
+                new Vector3d(62815.1711547398, 48914.513130238, 2500.0)
+        ));
+        list.add(poly(
+                new Vector3d(63459.7496755729, 48913.971239468, 0.0),
+                new Vector3d(63458.4604999209, 48948.4242817383, 0.0),
+                new Vector3d(63458.4604999209, 48948.4242817383, 2500.0),
+                new Vector3d(63459.7496755729, 48913.971239468, 2500.0)
+        ));
+        list.add(poly(
+                new Vector3d(63458.4604999209, 48948.4242817383, 0.0),
+                new Vector3d(62813.8517414851, 48947.842264303, 0.0),
+                new Vector3d(62813.8517414851, 48947.842264303, 2500.0),
+                new Vector3d(63458.4604999209, 48948.4242817383, 2500.0)
+        ));
+        list.add(poly(
+                new Vector3d(62813.8517414851, 48947.842264303, 0.0),
+                new Vector3d(62815.1711547398, 48914.513130238, 0.0),
+                new Vector3d(62815.1711547398, 48914.513130238, 2500.0),
+                new Vector3d(62813.8517414851, 48947.842264303, 2500.0)
+        ));
+        list.add(poly(
+                new Vector3d(62815.1711547398, 48914.513130238, 0.0),
+                new Vector3d(63459.7496755729, 48913.971239468, 0.0),
+                new Vector3d(63459.7496755729, 48913.971239468, 2500.0),
+                new Vector3d(62815.1711547398, 48914.513130238, 2500.0)
+        ));
+        list.add(poly(
+                new Vector3d(63459.7496755729, 48913.971239468, 0.0),
+                new Vector3d(62815.1711547398, 48914.513130238, 0.0),
+                new Vector3d(62813.8517414851, 48947.842264303, 0.0),
+                new Vector3d(63458.4604999209, 48948.4242817383, 0.0)
+        ));
+        return list;
+    }
+}


### PR DESCRIPTION
## Summary
- add a new example `TwoCellSpacesExample` to show two 3D cell spaces built from polygons
- document the example in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868d1223070832fa5292e4dc2aa9f6e