### PR TITLE
Add interactive 3D model creator and improve example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ Die Klassen konvertieren uebergebene CellSpaces, Transitions und States in entsp
 * **ChaseCameraExample** – demonstriert eine Orbit-Steuerung mit der JME-ChaseCamera, um das 3D-Modell per Maus zu drehen und zu zoomen.
 * **TwoCellSpacesExample** – baut zwei CellSpaces aus Polygonen auf, berechnet deren Schwerpunkte und verbindet sie mit einer Transition. Die Szene wird automatisch skaliert und zentriert. Jeder CellSpace besitzt eine eigene Farbe und wird halbtransparent dargestellt. Die Navigation erfolgt ueber eine ChaseCamera.
 * **MultiCellSpacesExample** – visualisiert eine beliebige Anzahl von CellSpaces, berechnet zu jedem den Schwerpunkt und verbindet die States ringfoermig. Vor der Darstellung wird die Szene skaliert und zentriert. Die CellSpaces erhalten abwechselnde Farben und sind halbtransparent. Die Navigation erfolgt ueber eine ChaseCamera.
+* **ModelInteractionExample** – nutzt das Datenmodell, erzeugt automatisch mehrere CellSpaces, States und Transitions. Objekte lassen sich per Maus auswählen, werden dabei hervorgehoben und können mit der Entf-Taste entfernt werden.
+* **CreateModel** – Hilfsklasse, die ein kleines Beispielmodell erzeugt und die Geometrie vor dem Anzeigen skaliert sowie zentriert.
 
 ## Datenmodell
 
-Die Klasse `IndoorGMLModel` verwaltet CellSpaces, States und Transitions. Jeder
-CellSpace und jeder Polygon besitzen eine eindeutige ID. Beim Hinzufügen eines
-CellSpace wird automatisch ein zugehöriger State mit neuer ID angelegt. Wird ein
-CellSpace entfernt, löscht das Modell auch den dazugehörigen State sowie alle
-Transitions, die auf diesen State verweisen.
+Die Klasse `IndoorGMLModel` verwaltet CellSpaces, States und Transitions jeweils in eigenen Listen.
+Jeder CellSpace und jede Geometrie besitzen eine eindeutige ID. Beim Hinzufügen eines
+CellSpace wird automatisch ein passender State erstellt und mitverwaltet. Beim Entfernen
+eines CellSpace oder State löscht das Modell auch alle zugehörigen Transitions.

--- a/src/main/java/org/indoorgml/example/CreateModel.java
+++ b/src/main/java/org/indoorgml/example/CreateModel.java
@@ -1,0 +1,156 @@
+package org.indoorgml.example;
+
+import org.indoorgml.model.CellSpace;
+import org.indoorgml.model.IndoorGMLModel;
+import org.indoorgml.model.Polygon;
+import org.indoorgml.model.StatePoint;
+import org.indoorgml.model.Vector3d;
+import org.indoorgml.util.GeometryUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Utility that builds a small example {@link IndoorGMLModel} containing
+ * a few cell spaces, their states and connecting transitions. The polygon
+ * data uses large coordinates which are scaled down and centered around
+ * the origin so the resulting scene fits nicely into the view.
+ */
+public final class CreateModel {
+
+    private CreateModel() {
+    }
+
+    /**
+     * Creates a sample model with multiple cell spaces.
+     */
+    public static IndoorGMLModel createModel() {
+        IndoorGMLModel model = new IndoorGMLModel();
+
+        List<CellSpace> cells = Arrays.asList(
+                createCellSpace1(),
+                createCellSpace2(),
+                createCellSpace3()
+        );
+
+        // collect polygons for transformation
+        List<Polygon> allPolygons = new ArrayList<>();
+        for (CellSpace cs : cells) {
+            allPolygons.addAll(cs.getPolygons());
+        }
+
+        // scale coordinates to a manageable size and move them around the origin
+        float scale = (float) (10.0 / GeometryUtils.computeMaxDimension(allPolygons));
+        GeometryUtils.applyScale(allPolygons, scale);
+        Vector3d center = GeometryUtils.computeBoundingCenter(allPolygons);
+        GeometryUtils.applyTranslation(allPolygons,
+                new Vector3d(-center.getX(), -center.getY(), -center.getZ()));
+
+        // add cells to the model (states are created automatically)
+        for (CellSpace cs : cells) {
+            model.addCellSpace(cs.getPolygons());
+        }
+
+        // connect all states with transitions in a simple ring
+        List<StatePoint> states = new ArrayList<>(model.getStates());
+        for (int i = 0; i < states.size(); i++) {
+            StatePoint a = states.get(i);
+            StatePoint b = states.get((i + 1) % states.size());
+            model.addTransition(a, b);
+        }
+
+        return model;
+    }
+
+    private static CellSpace createCellSpace1() {
+        CellSpace c = new CellSpace();
+        List<Polygon> list = new ArrayList<>();
+        list.add(poly(new Vector3d(62762.3590635083, 49638.2654653775, 2500.0),
+                new Vector3d(62775.3752335849, 48947.8075238529, 2500.0),
+                new Vector3d(63522.3102633086, 48948.4819317082, 2500.0),
+                new Vector3d(63515.4374949107, 49639.4237948367, 2500.0)));
+        list.add(poly(new Vector3d(62762.3590635083, 49638.2654653775, 0.0),
+                new Vector3d(62775.3752335849, 48947.8075238529, 0.0),
+                new Vector3d(62775.3752335849, 48947.8075238529, 2500.0),
+                new Vector3d(62762.3590635083, 49638.2654653775, 2500.0)));
+        list.add(poly(new Vector3d(62775.3752335849, 48947.8075238529, 0.0),
+                new Vector3d(63522.3102633086, 48948.4819317082, 0.0),
+                new Vector3d(63522.3102633086, 48948.4819317082, 2500.0),
+                new Vector3d(62775.3752335849, 48947.8075238529, 2500.0)));
+        list.add(poly(new Vector3d(63522.3102633086, 48948.4819317082, 0.0),
+                new Vector3d(63515.4374949107, 49639.4237948367, 0.0),
+                new Vector3d(63515.4374949107, 49639.4237948367, 2500.0),
+                new Vector3d(63522.3102633086, 48948.4819317082, 2500.0)));
+        list.add(poly(new Vector3d(63515.4374949107, 49639.4237948367, 0.0),
+                new Vector3d(62762.3590635083, 49638.2654653775, 0.0),
+                new Vector3d(62762.3590635083, 49638.2654653775, 2500.0),
+                new Vector3d(63515.4374949107, 49639.4237948367, 2500.0)));
+        list.add(poly(new Vector3d(62762.3590635083, 49638.2654653775, 0.0),
+                new Vector3d(63515.4374949107, 49639.4237948367, 0.0),
+                new Vector3d(63522.3102633086, 48948.4819317082, 0.0),
+                new Vector3d(62775.3752335849, 48947.8075238529, 0.0)));
+        c.setPolygons(list);
+        return c;
+    }
+
+    private static CellSpace createCellSpace2() {
+        CellSpace c = new CellSpace();
+        List<Polygon> list = new ArrayList<>();
+        list.add(poly(new Vector3d(63459.7496755729, 48913.971239468, 2500.0),
+                new Vector3d(63458.4604999209, 48948.4242817383, 2500.0),
+                new Vector3d(62813.8517414851, 48947.842264303, 2500.0),
+                new Vector3d(62815.1711547398, 48914.513130238, 2500.0)));
+        list.add(poly(new Vector3d(63459.7496755729, 48913.971239468, 0.0),
+                new Vector3d(63458.4604999209, 48948.4242817383, 0.0),
+                new Vector3d(63458.4604999209, 48948.4242817383, 2500.0),
+                new Vector3d(63459.7496755729, 48913.971239468, 2500.0)));
+        list.add(poly(new Vector3d(63458.4604999209, 48948.4242817383, 0.0),
+                new Vector3d(62813.8517414851, 48947.842264303, 0.0),
+                new Vector3d(62813.8517414851, 48947.842264303, 2500.0),
+                new Vector3d(63458.4604999209, 48948.4242817383, 2500.0)));
+        list.add(poly(new Vector3d(62813.8517414851, 48947.842264303, 0.0),
+                new Vector3d(62815.1711547398, 48914.513130238, 0.0),
+                new Vector3d(62815.1711547398, 48914.513130238, 2500.0),
+                new Vector3d(62813.8517414851, 48947.842264303, 2500.0)));
+        list.add(poly(new Vector3d(62815.1711547398, 48914.513130238, 0.0),
+                new Vector3d(63459.7496755729, 48913.971239468, 0.0),
+                new Vector3d(63459.7496755729, 48913.971239468, 2500.0),
+                new Vector3d(62815.1711547398, 48914.513130238, 2500.0)));
+        list.add(poly(new Vector3d(63459.7496755729, 48913.971239468, 0.0),
+                new Vector3d(62815.1711547398, 48914.513130238, 0.0),
+                new Vector3d(62813.8517414851, 48947.842264303, 0.0),
+                new Vector3d(63458.4604999209, 48948.4242817383, 0.0)));
+        c.setPolygons(list);
+        return c;
+    }
+
+    private static CellSpace createCellSpace3() {
+        CellSpace c = new CellSpace();
+        List<Polygon> list = new ArrayList<>();
+        list.add(poly(new Vector3d(62815.1711547398, 48914.513130238, 0.0),
+                new Vector3d(63065.2696380588, 48914.3028749233, 0.0),
+                new Vector3d(63459.7496755729, 48913.971239468, 0.0),
+                new Vector3d(63459.7496755729, 48913.971239468, 15.0),
+                new Vector3d(63065.2696380588, 48914.3028749233, 15.0),
+                new Vector3d(62815.1711547398, 48914.513130238, 15.0)));
+        c.setPolygons(list);
+        return c;
+    }
+
+    private static Polygon poly(Vector3d v1, Vector3d v2, Vector3d v3, Vector3d v4) {
+        Polygon poly = new Polygon();
+        poly.setVertices(Arrays.asList(v1, v2, v3, v4));
+        poly.setIndices(Arrays.asList(0, 1, 2, 0, 2, 3));
+        return poly;
+    }
+
+    private static Polygon poly(Vector3d v1, Vector3d v2, Vector3d v3,
+                                Vector3d v4, Vector3d v5, Vector3d v6) {
+        Polygon poly = new Polygon();
+        poly.setVertices(Arrays.asList(v1, v2, v3, v4, v5, v6));
+        poly.setIndices(Arrays.asList(0, 1, 5, 5, 4, 1, 1, 4, 2, 2, 4, 3));
+        return poly;
+    }
+}
+

--- a/src/main/java/org/indoorgml/example/ModelInteractionExample.java
+++ b/src/main/java/org/indoorgml/example/ModelInteractionExample.java
@@ -1,0 +1,186 @@
+package org.indoorgml.example;
+
+import com.jme3.app.SimpleApplication;
+import com.jme3.collision.CollisionResults;
+import com.jme3.input.ChaseCamera;
+import com.jme3.input.MouseInput;
+import com.jme3.input.controls.ActionListener;
+import com.jme3.input.controls.MouseButtonTrigger;
+import com.jme3.input.controls.KeyTrigger;
+import com.jme3.input.KeyInput;
+import com.jme3.math.ColorRGBA;
+import com.jme3.math.Vector2f;
+import com.jme3.math.Vector3f;
+import com.jme3.math.Ray;
+import com.jme3.scene.Geometry;
+import com.jme3.scene.Node;
+
+import org.indoorgml.model.CellSpace;
+import org.indoorgml.model.StatePoint;
+import org.indoorgml.model.Transition;
+import org.indoorgml.model.IndoorGMLModel;
+import org.indoorgml.example.CreateModel;
+import org.indoorgml.visualizer.CellSpaceGeometryBuilder;
+import org.indoorgml.visualizer.StateGeometryBuilder;
+import org.indoorgml.visualizer.TransitionGeometryBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Example that uses IndoorGMLModel to create CellSpaces with
+ * automatically generated States and Transitions. Clicking on the
+ * geometries prints their IDs to the console.
+ */
+public class ModelInteractionExample extends SimpleApplication {
+
+    private IndoorGMLModel model;
+    private ChaseCamera chaseCam;
+    private Node scene;
+    private final java.util.List<Geometry> selected = new java.util.ArrayList<>();
+
+    public static void main(String[] args) {
+        ModelInteractionExample app = new ModelInteractionExample();
+        app.start();
+    }
+
+    @Override
+    public void simpleInitApp() {
+        model = CreateModel.createModel();
+        scene = createScene();
+        rootNode.attachChild(scene);
+
+        inputManager.addMapping("select", new MouseButtonTrigger(MouseInput.BUTTON_LEFT));
+        inputManager.addListener(actionListener, "select");
+        inputManager.addMapping("delete", new KeyTrigger(KeyInput.KEY_DELETE));
+        inputManager.addListener(actionListener, "delete");
+
+        flyCam.setEnabled(false);
+        chaseCam = new ChaseCamera(cam, scene, inputManager);
+        chaseCam.setDefaultDistance(6f);
+        chaseCam.setDragToRotate(true);
+    }
+
+    private Node createScene() {
+        Node node = new Node("scene");
+        ColorRGBA[] colors = new ColorRGBA[] {
+                ColorRGBA.Blue,
+                ColorRGBA.Orange,
+                ColorRGBA.Cyan,
+                ColorRGBA.Magenta,
+                ColorRGBA.Brown
+        };
+        int idx = 0;
+        for (CellSpace cs : model.getCellSpaces()) {
+            ColorRGBA color = colors[idx % colors.length];
+            node.attachChild(CellSpaceGeometryBuilder.buildCellSpacesFromCells(
+                    List.of(cs), assetManager, color, 0.5f));
+            idx++;
+        }
+        node.attachChild(StateGeometryBuilder.buildStates(new ArrayList<>(model.getStates()), assetManager));
+        node.attachChild(TransitionGeometryBuilder.buildTransitionsFromTransitions(
+                new ArrayList<>(model.getTransitions()), assetManager));
+        return node;
+    }
+
+    private void selectAtCursor() {
+        clearSelection();
+        Vector2f click2d = inputManager.getCursorPosition();
+        Vector3f origin = cam.getWorldCoordinates(click2d, 0f);
+        Vector3f direction = cam.getWorldCoordinates(click2d, 1f).subtractLocal(origin).normalizeLocal();
+        Ray ray = new Ray(origin, direction);
+        CollisionResults results = new CollisionResults();
+        rootNode.collideWith(ray, results);
+        if (results.size() > 0) {
+            Geometry g = results.getClosestCollision().getGeometry();
+            String cellId = g.getUserData("cellId");
+            String polygonId = g.getUserData("polygonId");
+            String stateId = g.getUserData("stateId");
+            String transitionId = g.getUserData("transitionId");
+            if (cellId != null) {
+                highlightWithId("cellId", cellId);
+                System.out.println("Clicked CellSpace " + cellId + " (" + polygonId + ")");
+            } else if (stateId != null) {
+                highlightWithId("stateId", stateId);
+                System.out.println("Clicked State " + stateId);
+            } else if (transitionId != null) {
+                highlightWithId("transitionId", transitionId);
+                System.out.println("Clicked Transition " + transitionId);
+            }
+        }
+    }
+
+    private void deleteSelection() {
+        if (selected.isEmpty()) {
+            return;
+        }
+        Geometry g = selected.get(0);
+        String cellId = g.getUserData("cellId");
+        String stateId = g.getUserData("stateId");
+        String transitionId = g.getUserData("transitionId");
+        if (cellId != null) {
+            model.removeCellSpace(cellId);
+        } else if (stateId != null) {
+            model.removeState(stateId);
+        } else if (transitionId != null) {
+            model.removeTransition(transitionId);
+        }
+        rebuildScene();
+    }
+
+    private void highlightWithId(String key, String id) {
+        java.util.ArrayDeque<com.jme3.scene.Spatial> stack = new java.util.ArrayDeque<>();
+        stack.add(scene);
+        while (!stack.isEmpty()) {
+            com.jme3.scene.Spatial s = stack.poll();
+            if (s instanceof Geometry geom) {
+                String val = geom.getUserData(key);
+                if (id.equals(val)) {
+                    ColorRGBA base = geom.getUserData("baseColor");
+                    ColorRGBA highlight = ColorRGBA.Yellow.clone();
+                    if (base != null) {
+                        highlight.a = base.a;
+                    }
+                    geom.getMaterial().setColor("Color", highlight);
+                    selected.add(geom);
+                }
+            }
+            if (s instanceof Node node) {
+                stack.addAll(node.getChildren());
+            }
+        }
+    }
+
+    private void clearSelection() {
+        for (Geometry geom : selected) {
+            ColorRGBA base = geom.getUserData("baseColor");
+            if (base != null) {
+                geom.getMaterial().setColor("Color", base);
+            }
+        }
+        selected.clear();
+    }
+
+    private void rebuildScene() {
+        rootNode.detachChild(scene);
+        scene = createScene();
+        rootNode.attachChild(scene);
+        chaseCam.setSpatial(scene);
+        clearSelection();
+    }
+
+    private final ActionListener actionListener = new ActionListener() {
+        @Override
+        public void onAction(String name, boolean isPressed, float tpf) {
+            if (!isPressed) {
+                return;
+            }
+            if ("select".equals(name)) {
+                selectAtCursor();
+            } else if ("delete".equals(name)) {
+                deleteSelection();
+            }
+        }
+    };
+}
+

--- a/src/main/java/org/indoorgml/example/MultiCellSpacesExample.java
+++ b/src/main/java/org/indoorgml/example/MultiCellSpacesExample.java
@@ -11,6 +11,7 @@ import org.indoorgml.model.Vector3d;
 import org.indoorgml.visualizer.CellSpaceGeometryBuilder;
 import org.indoorgml.visualizer.StateGeometryBuilder;
 import org.indoorgml.visualizer.TransitionGeometryBuilder;
+import org.indoorgml.util.GeometryUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,10 +46,10 @@ public class MultiCellSpacesExample extends SimpleApplication {
 
         // Scale large coordinates down and translate them so the geometry is
         // centered around the origin before creating the scene graph.
-        float scale = (float) (10.0 / computeMaxDimension(allPolygons));
+        float scale = (float) (10.0 / GeometryUtils.computeMaxDimension(allPolygons));
         applyScale(allPolygons, transitions, states, scale);
 
-        Vector3d center = computeBoundingCenter(allPolygons);
+        Vector3d center = GeometryUtils.computeBoundingCenter(allPolygons);
         applyTranslation(allPolygons, transitions, states,
                 -center.getX(), -center.getY(), -center.getZ());
 
@@ -104,55 +105,6 @@ public class MultiCellSpacesExample extends SimpleApplication {
         return state;
     }
 
-    private double computeMaxDimension(List<Polygon> polygons) {
-        double minX = Double.POSITIVE_INFINITY;
-        double minY = Double.POSITIVE_INFINITY;
-        double minZ = Double.POSITIVE_INFINITY;
-        double maxX = Double.NEGATIVE_INFINITY;
-        double maxY = Double.NEGATIVE_INFINITY;
-        double maxZ = Double.NEGATIVE_INFINITY;
-
-        for (Polygon poly : polygons) {
-            for (Vector3d v : poly.getVertices()) {
-                minX = Math.min(minX, v.getX());
-                minY = Math.min(minY, v.getY());
-                minZ = Math.min(minZ, v.getZ());
-                maxX = Math.max(maxX, v.getX());
-                maxY = Math.max(maxY, v.getY());
-                maxZ = Math.max(maxZ, v.getZ());
-            }
-        }
-
-        double dx = maxX - minX;
-        double dy = maxY - minY;
-        double dz = maxZ - minZ;
-        return Math.max(dx, Math.max(dy, dz));
-    }
-
-    private Vector3d computeBoundingCenter(List<Polygon> polygons) {
-        double minX = Double.POSITIVE_INFINITY;
-        double minY = Double.POSITIVE_INFINITY;
-        double minZ = Double.POSITIVE_INFINITY;
-        double maxX = Double.NEGATIVE_INFINITY;
-        double maxY = Double.NEGATIVE_INFINITY;
-        double maxZ = Double.NEGATIVE_INFINITY;
-
-        for (Polygon poly : polygons) {
-            for (Vector3d v : poly.getVertices()) {
-                minX = Math.min(minX, v.getX());
-                minY = Math.min(minY, v.getY());
-                minZ = Math.min(minZ, v.getZ());
-                maxX = Math.max(maxX, v.getX());
-                maxY = Math.max(maxY, v.getY());
-                maxZ = Math.max(maxZ, v.getZ());
-            }
-        }
-
-        return new Vector3d(
-                (minX + maxX) / 2.0,
-                (minY + maxY) / 2.0,
-                (minZ + maxZ) / 2.0);
-    }
 
     private void applyScale(List<Polygon> polygons, List<LineString> lines,
                             List<StatePoint> states, double s) {

--- a/src/main/java/org/indoorgml/example/TwoCellSpacesExample.java
+++ b/src/main/java/org/indoorgml/example/TwoCellSpacesExample.java
@@ -11,6 +11,7 @@ import org.indoorgml.model.Vector3d;
 import org.indoorgml.visualizer.CellSpaceGeometryBuilder;
 import org.indoorgml.visualizer.StateGeometryBuilder;
 import org.indoorgml.visualizer.TransitionGeometryBuilder;
+import org.indoorgml.util.GeometryUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,10 +49,10 @@ public class TwoCellSpacesExample extends SimpleApplication {
 
         // Scale large coordinates down and translate them so the geometry is
         // centered around the origin before creating the scene graph.
-        float scale = (float) (10.0 / computeMaxDimension(allPolygons));
+        float scale = (float) (10.0 / GeometryUtils.computeMaxDimension(allPolygons));
         applyScale(allPolygons, transitions, states, scale);
 
-        Vector3d center = computeBoundingCenter(allPolygons);
+        Vector3d center = GeometryUtils.computeBoundingCenter(allPolygons);
         applyTranslation(allPolygons, transitions, states,
                 -center.getX(), -center.getY(), -center.getZ());
 
@@ -99,55 +100,6 @@ public class TwoCellSpacesExample extends SimpleApplication {
         return state;
     }
 
-    private double computeMaxDimension(List<Polygon> polygons) {
-        double minX = Double.POSITIVE_INFINITY;
-        double minY = Double.POSITIVE_INFINITY;
-        double minZ = Double.POSITIVE_INFINITY;
-        double maxX = Double.NEGATIVE_INFINITY;
-        double maxY = Double.NEGATIVE_INFINITY;
-        double maxZ = Double.NEGATIVE_INFINITY;
-
-        for (Polygon poly : polygons) {
-            for (Vector3d v : poly.getVertices()) {
-                minX = Math.min(minX, v.getX());
-                minY = Math.min(minY, v.getY());
-                minZ = Math.min(minZ, v.getZ());
-                maxX = Math.max(maxX, v.getX());
-                maxY = Math.max(maxY, v.getY());
-                maxZ = Math.max(maxZ, v.getZ());
-            }
-        }
-
-        double dx = maxX - minX;
-        double dy = maxY - minY;
-        double dz = maxZ - minZ;
-        return Math.max(dx, Math.max(dy, dz));
-    }
-
-    private Vector3d computeBoundingCenter(List<Polygon> polygons) {
-        double minX = Double.POSITIVE_INFINITY;
-        double minY = Double.POSITIVE_INFINITY;
-        double minZ = Double.POSITIVE_INFINITY;
-        double maxX = Double.NEGATIVE_INFINITY;
-        double maxY = Double.NEGATIVE_INFINITY;
-        double maxZ = Double.NEGATIVE_INFINITY;
-
-        for (Polygon poly : polygons) {
-            for (Vector3d v : poly.getVertices()) {
-                minX = Math.min(minX, v.getX());
-                minY = Math.min(minY, v.getY());
-                minZ = Math.min(minZ, v.getZ());
-                maxX = Math.max(maxX, v.getX());
-                maxY = Math.max(maxY, v.getY());
-                maxZ = Math.max(maxZ, v.getZ());
-            }
-        }
-
-        return new Vector3d(
-                (minX + maxX) / 2.0,
-                (minY + maxY) / 2.0,
-                (minZ + maxZ) / 2.0);
-    }
 
     private void applyScale(List<Polygon> polygons, List<LineString> lines,
                             List<StatePoint> states, double s) {

--- a/src/main/java/org/indoorgml/model/IndoorGMLModel.java
+++ b/src/main/java/org/indoorgml/model/IndoorGMLModel.java
@@ -7,6 +7,7 @@ import java.util.*;
  */
 public class IndoorGMLModel {
     private final Map<String, CellSpace> cellSpaces = new LinkedHashMap<>();
+    private final Map<String, StatePoint> states = new LinkedHashMap<>();
     private final Map<String, Transition> transitions = new LinkedHashMap<>();
     private int cellCounter = 1;
     private int stateCounter = 1;
@@ -29,6 +30,7 @@ public class IndoorGMLModel {
         state.setId("S" + stateCounter++);
         state.setPosition(computeCentroid(polygons));
         cell.setState(state);
+        states.put(state.getId(), state);
         cellSpaces.put(cellId, cell);
         return cell;
     }
@@ -42,6 +44,7 @@ public class IndoorGMLModel {
             return;
         }
         String stateId = cell.getState().getId();
+        states.remove(stateId);
         transitions.values().removeIf(t ->
                 t.getStateA().getId().equals(stateId) ||
                         t.getStateB().getId().equals(stateId));
@@ -67,8 +70,28 @@ public class IndoorGMLModel {
         return cellSpaces.values();
     }
 
+    public Collection<StatePoint> getStates() {
+        return states.values();
+    }
+
     public Collection<Transition> getTransitions() {
         return transitions.values();
+    }
+
+    public void removeState(String stateId) {
+        states.remove(stateId);
+        cellSpaces.values().forEach(cs -> {
+            if (cs.getState() != null && cs.getState().getId().equals(stateId)) {
+                cs.setState(null);
+            }
+        });
+        transitions.values().removeIf(t ->
+                t.getStateA().getId().equals(stateId) ||
+                        t.getStateB().getId().equals(stateId));
+    }
+
+    public void removeTransition(String transitionId) {
+        transitions.remove(transitionId);
     }
 
     private Vector3d computeCentroid(List<Polygon> polygons) {

--- a/src/main/java/org/indoorgml/util/GeometryUtils.java
+++ b/src/main/java/org/indoorgml/util/GeometryUtils.java
@@ -1,0 +1,97 @@
+package org.indoorgml.util;
+
+import org.indoorgml.model.Polygon;
+import org.indoorgml.model.Vector3d;
+
+import java.util.List;
+
+/**
+ * Static helper methods for simple geometry transformations.
+ */
+public final class GeometryUtils {
+
+    private GeometryUtils() {
+    }
+
+    /**
+     * Computes the center of the bounding box of all polygons.
+     */
+    public static Vector3d computeBoundingCenter(List<Polygon> polygons) {
+        double minX = Double.POSITIVE_INFINITY;
+        double minY = Double.POSITIVE_INFINITY;
+        double minZ = Double.POSITIVE_INFINITY;
+        double maxX = Double.NEGATIVE_INFINITY;
+        double maxY = Double.NEGATIVE_INFINITY;
+        double maxZ = Double.NEGATIVE_INFINITY;
+
+        for (Polygon poly : polygons) {
+            for (Vector3d v : poly.getVertices()) {
+                minX = Math.min(minX, v.getX());
+                minY = Math.min(minY, v.getY());
+                minZ = Math.min(minZ, v.getZ());
+                maxX = Math.max(maxX, v.getX());
+                maxY = Math.max(maxY, v.getY());
+                maxZ = Math.max(maxZ, v.getZ());
+            }
+        }
+
+        return new Vector3d(
+                (minX + maxX) / 2.0,
+                (minY + maxY) / 2.0,
+                (minZ + maxZ) / 2.0);
+    }
+
+    /**
+     * Returns the largest dimension of the bounding box covering all polygons.
+     */
+    public static double computeMaxDimension(List<Polygon> polygons) {
+        double minX = Double.POSITIVE_INFINITY;
+        double minY = Double.POSITIVE_INFINITY;
+        double minZ = Double.POSITIVE_INFINITY;
+        double maxX = Double.NEGATIVE_INFINITY;
+        double maxY = Double.NEGATIVE_INFINITY;
+        double maxZ = Double.NEGATIVE_INFINITY;
+
+        for (Polygon poly : polygons) {
+            for (Vector3d v : poly.getVertices()) {
+                minX = Math.min(minX, v.getX());
+                minY = Math.min(minY, v.getY());
+                minZ = Math.min(minZ, v.getZ());
+                maxX = Math.max(maxX, v.getX());
+                maxY = Math.max(maxY, v.getY());
+                maxZ = Math.max(maxZ, v.getZ());
+            }
+        }
+
+        double dx = maxX - minX;
+        double dy = maxY - minY;
+        double dz = maxZ - minZ;
+        return Math.max(dx, Math.max(dy, dz));
+    }
+
+    /**
+     * Scales all polygon vertices by the given factor.
+     */
+    public static void applyScale(List<Polygon> polygons, double s) {
+        for (Polygon poly : polygons) {
+            for (Vector3d v : poly.getVertices()) {
+                v.setX(v.getX() * s);
+                v.setY(v.getY() * s);
+                v.setZ(v.getZ() * s);
+            }
+        }
+    }
+
+    /**
+     * Translates all polygon vertices by the given offset vector.
+     */
+    public static void applyTranslation(List<Polygon> polygons, Vector3d offset) {
+        for (Polygon poly : polygons) {
+            for (Vector3d v : poly.getVertices()) {
+                v.setX(v.getX() + offset.getX());
+                v.setY(v.getY() + offset.getY());
+                v.setZ(v.getZ() + offset.getZ());
+            }
+        }
+    }
+}

--- a/src/main/java/org/indoorgml/visualizer/CellSpaceGeometryBuilder.java
+++ b/src/main/java/org/indoorgml/visualizer/CellSpaceGeometryBuilder.java
@@ -59,7 +59,10 @@ public class CellSpaceGeometryBuilder {
         boolean transparent = alpha < 1f;
         for (CellSpace cs : cells) {
             for (Polygon poly : cs.getPolygons()) {
-                node.attachChild(buildGeometry(poly, material, transparent));
+                Geometry geom = buildGeometry(poly, material, transparent);
+                geom.setUserData("cellId", cs.getId());
+                geom.setUserData("polygonId", poly.getId());
+                node.attachChild(geom);
             }
         }
         return node;
@@ -88,7 +91,9 @@ public class CellSpaceGeometryBuilder {
         mesh.updateBound();
 
         Geometry geom = new Geometry("cellSpace", mesh);
-        geom.setMaterial(material);
+        geom.setMaterial(material.clone());
+        ColorRGBA base = material.getParam("Color").getValue();
+        geom.setUserData("baseColor", base.clone());
         if (transparent) {
             geom.setQueueBucket(RenderQueue.Bucket.Transparent);
         }

--- a/src/main/java/org/indoorgml/visualizer/StateGeometryBuilder.java
+++ b/src/main/java/org/indoorgml/visualizer/StateGeometryBuilder.java
@@ -37,9 +37,12 @@ public class StateGeometryBuilder {
     private static Geometry buildGeometry(StatePoint state, Material material) {
         Sphere sphere = new Sphere(10, 10, RADIUS);
         Geometry geom = new Geometry("state", sphere);
-        geom.setMaterial(material);
+        geom.setMaterial(material.clone());
+        ColorRGBA base = material.getParam("Color").getValue();
+        geom.setUserData("baseColor", base.clone());
         Vector3d pos = state.getPosition();
         geom.setLocalTranslation(new Vector3f((float) pos.getX(), (float) pos.getY(), (float) pos.getZ()));
+        geom.setUserData("stateId", state.getId());
         return geom;
     }
 

--- a/src/main/java/org/indoorgml/visualizer/TransitionGeometryBuilder.java
+++ b/src/main/java/org/indoorgml/visualizer/TransitionGeometryBuilder.java
@@ -12,6 +12,7 @@ import com.jme3.util.BufferUtils;
 
 import org.indoorgml.model.LineString;
 import org.indoorgml.model.Vector3d;
+import org.indoorgml.model.Transition;
 
 import java.util.List;
 
@@ -33,6 +34,18 @@ public class TransitionGeometryBuilder {
         return node;
     }
 
+    public static Node buildTransitionsFromTransitions(List<Transition> transitions,
+                                                       AssetManager assetManager) {
+        Node node = new Node("transitions");
+        Material material = defaultMaterial(assetManager);
+        for (Transition t : transitions) {
+            Geometry geom = buildGeometry(t.getGeometry(), material);
+            geom.setUserData("transitionId", t.getId());
+            node.attachChild(geom);
+        }
+        return node;
+    }
+
     private static Geometry buildGeometry(LineString line, Material material) {
         Mesh mesh = new Mesh();
 
@@ -49,7 +62,9 @@ public class TransitionGeometryBuilder {
         mesh.updateBound();
 
         Geometry geom = new Geometry("transition", mesh);
-        geom.setMaterial(material);
+        geom.setMaterial(material.clone());
+        ColorRGBA base = material.getParam("Color").getValue();
+        geom.setUserData("baseColor", base.clone());
         return geom;
     }
 


### PR DESCRIPTION
## Summary
- add `CreateModel` helper for generating a scaled IndoorGMLModel
- update `ModelInteractionExample` to use the new helper and color cells individually
- document the helper in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686910b324b4832fa9bf8e04ab3f1334